### PR TITLE
Fix `vim-ripgrep`

### DIFF
--- a/vim/rcfiles/leader_commands
+++ b/vim/rcfiles/leader_commands
@@ -10,4 +10,7 @@ nnoremap <Leader><Space> :%s/\s\+$//e<CR>
 " Clear the screen
 nnoremap <Leader>c :!clear<CR><CR>
 
+" Search for the word under the cursor
+nnoremap <Leader>? :Rg<CR>
+
 " vim:ft=vim

--- a/vim/rcplugins/fzf
+++ b/vim/rcplugins/fzf
@@ -1,6 +1,0 @@
-" fzf
-" A basic fzf wrapper function for Vim
-
-Plug 'junegunn/fzf.vim'
-
-" vim:ft=vim

--- a/vim/rcplugins/ripgrep
+++ b/vim/rcplugins/ripgrep
@@ -1,9 +1,9 @@
 " ripgrep
 " Search with RipGrep and show results in a quickfix list
 
-" Plug 'jremmen/vim-ripgrep'
+Plug 'jremmen/vim-ripgrep'
 
-" Waiting for https://github.com/jremmen/vim-ripgrep/pull/58 to close
-Plug 'lamchau/vim-ripgrep', { 'branch': 'patch-1' }
+" Search from derived project root
+let g:rg_derive_root = 1
 
 " vim:ft=vim


### PR DESCRIPTION
Remove the `fzf` plugin so that `:Rg` works properly. When both `fzf`
and `vim-ripgrep` are installed, they both want to use the same command.
I still don't know how to use `fzf`, so uninstalling it seems like the
thing to do.