### PR TITLE
Add a place to run Vim commands on save

### DIFF
--- a/vim/rcfiles/on_save
+++ b/vim/rcfiles/on_save
@@ -1,0 +1,9 @@
+" Commands to run on save
+
+augroup onSaveGroup
+  autocmd!
+
+  autocmd BufWritePost */Code/cai-custom-fields/* :Silent ~/Code/cai-custom-fields/bin/dev_sync.sh
+augroup end
+
+" vim:ft=vim


### PR DESCRIPTION
Add an entire file for the supremely useful `BufWritePost` autocommand.