### PR TITLE
Fix bug in `update_spell`

### DIFF
--- a/bin/update_spell
+++ b/bin/update_spell
@@ -76,7 +76,7 @@ git_commit() {
   git stash -u
   git checkout "$current_branch"
   git rebase main
-  git stash pop
+  git stash show >/dev/null 2>&1 && git stash pop
   git branch -d main-bak
 }
 


### PR DESCRIPTION
Prevent an early exit by checking if the stash has any entries before
attempting to pop it.