### PR TITLE
Wrap Heroku commands and overwrite `TERM`

### DIFF
--- a/zsh/functions/heroku
+++ b/zsh/functions/heroku
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Wrap commands that interact with the Heroku CLI and set the TERM variable to
+# xterm, since Alacritty isn't a supported terminal type
+
+heroku() {
+  TERM=xterm command heroku "$@"
+}

--- a/zsh/functions/production
+++ b/zsh/functions/production
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Wrap commands that interact with the Heroku CLI and set the TERM variable to
+# xterm, since Alacritty isn't a supported terminal type
+
+production() {
+  TERM=xterm command production "$@"
+}

--- a/zsh/functions/staging
+++ b/zsh/functions/staging
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Wrap commands that interact with the Heroku CLI and set the TERM variable to
+# xterm, since Alacritty isn't a supported terminal type
+
+staging() {
+  TERM=xterm command staging "$@"
+}


### PR DESCRIPTION
When interacting with the Heroku CLI, ensure `TERM` is set to `xterm`,
and not `alacritty`, since Alacritty is not supported.