### PR TITLE
Fix `pwg`

### DIFF
--- a/bin/pwg
+++ b/bin/pwg
@@ -1,17 +1,14 @@
 #!/bin/bash
-# Uses `/dev/urandom` to generate an alphanumeric string of N characters.
+# Uses OpenSSL to generate an alphanumeric string of N characters.
 
-set -e
+set -eo pipefail
 
-yank=''
-length=32
+length="$1"
 
 get_options() {
-  while getopts 'hl:y' flag; do
+  while getopts 'h' flag; do
     case "${flag}" in
       h) print_usage; exit ;;
-      l) length="${OPTARG}" ;;
-      y) yank='true' ;;
       *) print_usage; exit 1 ;;
     esac
   done
@@ -19,22 +16,28 @@ get_options() {
 
 print_usage() {
 cat <<EOM
-Usage: pwg [OPTION]
+Usage: pwg [LENGTH]
 
 Options:
   -h          display this help message
-  -l [ARG]    length of the generated password (default: 32)
-  -y          copy the generated password to the clipboard
 
 EOM
 }
 
+check_for_openssl() {
+  command -v openssl >/dev/null 2>&1
+}
+
+openssl_error() {
+  echo >&2 "OpenSSL not found (is it installed?)"
+  exit 1
+}
+
 generate_password() {
-  if [ -n "$yank" ]; then
-    pwg | pbcopy
-  else
-    pwg
-  fi
+  local password="$(pwg)"
+
+  echo -n "$password" | pbcopy
+  echo "$password"
 }
 
 pwg() {
@@ -44,14 +47,11 @@ pwg() {
     length=32
   fi
 
-  local string="$( \
-    head /dev/urandom \
-      | LC_CTYPE=C tr -dc "[:alnum:]" \
-      | head -c "$length" \
-    )"
+  local string="$(openssl rand -hex $length | head -c $length)"
 
   echo "$string"
 }
 
 get_options "$@"
+check_for_openssl || openssl_error
 generate_password

--- a/bin/salts
+++ b/bin/salts
@@ -5,12 +5,12 @@ set -e
 
 cat <<EOM
 # Salts
-AUTH_KEY="$(pwg -l 64)"
-SECURE_AUTH_KEY="$(pwg -l 64)"
-LOGGED_IN_KEY="$(pwg -l 64)"
-NONCE_KEY="$(pwg -l 64)"
-AUTH_SALT="$(pwg -l 64)"
-SECURE_AUTH_SALT="$(pwg -l 64)"
-LOGGED_IN_SALT="$(pwg -l 64)"
-NONCE_SALT="$(pwg -l 64)"
+AUTH_KEY="$(pwg 64)"
+SECURE_AUTH_KEY="$(pwg 64)"
+LOGGED_IN_KEY="$(pwg 64)"
+NONCE_KEY="$(pwg 64)"
+AUTH_SALT="$(pwg 64)"
+SECURE_AUTH_SALT="$(pwg 64)"
+LOGGED_IN_SALT="$(pwg 64)"
+NONCE_SALT="$(pwg 64)"
 EOM

--- a/bin/show_note
+++ b/bin/show_note
@@ -4,10 +4,10 @@ note="$1"
 
 file="$(basename -- "$note")"
 file_without_ext="${file%.*}"
-url="https://notes.boynton.cloud/$file_without_ext.html"
+url="https://notes.jamesboynton.org/$file_without_ext"
 
 copy_note_url() {
-  echo "$url" | pbcopy
+  echo -n "$url" | pbcopy
 }
 
 show_note() {

--- a/bin/work/search_snapshots
+++ b/bin/work/search_snapshots
@@ -1,6 +1,10 @@
 #!/bin/bash
+# Search for snapshots on DigitalOcean
 
-echo
+[ -n "$1" ] || \
+  echo "Error: first argument must be the search term (client name)"; \
+  exit 1
+
 echo "Searching..."
 
 list="$(doctl compute snapshot list --format ID,Name,CreatedAt,Size)"
@@ -12,5 +16,5 @@ echo
 echo "$header"
 echo "$results"
 echo
-echo "$ids" | pbcopy
+echo -n "$ids" | pbcopy
 echo "IDs copied to clipboard"


### PR DESCRIPTION
Fix the `pwg` script so that it works. In the process, I discovered the
reason why I often find an unexpected newline when I paste something
that was copied in a script using `pbcopy`. Turns out, `echo -n ...` is
the answer.